### PR TITLE
Attempt fixing timeout of 5.9 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ install:
   # Qt
   - if [ ! -d "${QT_INSTALL_PATH}" ] ; then curl -L -O https://download.qt.io/archive/qt/${PYSIDE_BRANCH}/${QT_VER}/${QT_INSTALLER_FILE}.dmg ; fi
   - if [ ! -d "${QT_INSTALL_PATH}" ] ; then hdiutil attach -noverify ${QT_INSTALLER_FILE}.dmg ; fi
-  - if [ ! -d "${QT_INSTALL_PATH}" ] ; then travis_wait 50 /Volumes/${QT_INSTALLER_FILE}/${QT_INSTALLER_FILE}.app/Contents/MacOS/${QT_INSTALLER_FILE} --script qt-installer-${QT_VER}-noninteractive.qs -platform minimal ; fi
+  - if [ ! -d "${QT_INSTALL_PATH}" ] ; then travis_wait 15 /Volumes/${QT_INSTALLER_FILE}/${QT_INSTALLER_FILE}.app/Contents/MacOS/${QT_INSTALLER_FILE} --script qt-installer-${QT_VER}-noninteractive.qs -platform minimal ; fi
   - if [ -d "/Volumes/${QT_INSTALLER_FILE}" ] ; then hdiutil detach /Volumes/${QT_INSTALLER_FILE} ; fi
   - rm -rf ${QT_INSTALLER_FILE}.dmg
 

--- a/qt-installer-5.9.4-noninteractive.qs
+++ b/qt-installer-5.9.4-noninteractive.qs
@@ -28,8 +28,31 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
-    widget.selectAll();
-    widget.deselectComponent('qt.594.src')
+    // widget.selectAll();
+    widget.deselectAll();
+
+    widget.selectComponent("qt.594.clang_64")
+    // widget.selectComponent("qt.594.doc")
+    // widget.selectComponent("qt.594.examples")
+    widget.selectComponent("qt.594.qtcharts")
+    widget.selectComponent("qt.594.qtcharts.clang_64")
+    widget.selectComponent("qt.594.qtdatavis3d")
+    widget.selectComponent("qt.594.qtdatavis3d.clang_64")
+    widget.selectComponent("qt.594.qtnetworkauth")
+    widget.selectComponent("qt.594.qtnetworkauth.clang_64")
+    widget.selectComponent("qt.594.qtpurchasing")
+    widget.selectComponent("qt.594.qtpurchasing.clang_64")
+    widget.selectComponent("qt.594.qtremoteobjects")
+    widget.selectComponent("qt.594.qtremoteobjects.clang_64")
+    widget.selectComponent("qt.594.qtscript")
+    widget.selectComponent("qt.594.qtspeech")
+    widget.selectComponent("qt.594.qtspeech.clang_64")
+    widget.selectComponent("qt.594.qtvirtualkeyboard")
+    widget.selectComponent("qt.594.qtvirtualkeyboard.clang_64")
+    widget.selectComponent("qt.594.qtwebengine")
+    widget.selectComponent("qt.594.qtwebengine.clang_64")
+    // widget.selectComponent("qt.594.src")
+    widget.selectComponent("qt.tools.qtcreator")
 
     gui.clickButton(buttons.NextButton);
 }


### PR DESCRIPTION
Setting `travis_wait` to 15. This prevents a build from hanging for ~50 minutes during Qt install.
If the build fails after this 15 minute timeout, it's likely the build wouldn't complete anyways.

I'll also revert the change of the install script, where we install everything but the source.