### PR TITLE
Remove branch build limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-    - "master"
-
 matrix:
   include:
 


### PR DESCRIPTION
It didn't quite work to define the master branch to be the only branch to be built, as tags won't get built and therefore no wheels are attached to them.

I'm just disabling this for now.